### PR TITLE
Update ILAMB (v2.7.2)

### DIFF
--- a/environments/access-med/environment.yml
+++ b/environments/access-med/environment.yml
@@ -2,6 +2,7 @@ name: med-condaenv
 channels:
 - conda-forge
 - accessnri
+- nodefaults
 variables:
   CARTOPY_USER_BACKGROUNDS: /g/data/xp65/public/apps/cartopy-data/backgrounds
 dependencies:

--- a/environments/access-med/environment.yml
+++ b/environments/access-med/environment.yml
@@ -30,7 +30,7 @@ dependencies:
 - iris-esmf-regrid
 - iris-grib
 - intake
-- access-nri-intake>=0.1.5
+- access-nri-intake
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - mo_pack
 - nodejs>=20.0.0
@@ -63,7 +63,7 @@ dependencies:
 - shapely
 - cf_xarray
 - sparse
-- access-nri::ucx-py
+- accessnri::ucx-py
 - xgboost >1.6.1  # github.com/ESMValGroup/ESMValTool/issues/2779
 - med-diagnostics==0.0.1 # pining for now
 - access-med-tools==0.1.9

--- a/environments/access-med/environment.yml
+++ b/environments/access-med/environment.yml
@@ -63,7 +63,7 @@ dependencies:
 - shapely
 - cf_xarray
 - sparse
-- accessnri::ucx-py
+- coecms::ucx-py
 - xgboost >1.6.1  # github.com/ESMValGroup/ESMValTool/issues/2779
 - med-diagnostics==0.0.1 # pining for now
 - access-med-tools==0.1.9

--- a/environments/access-med/environment.yml
+++ b/environments/access-med/environment.yml
@@ -62,7 +62,7 @@ dependencies:
 - shapely
 - cf_xarray
 - sparse
-- coecms::ucx-py
+- access-nri::ucx-py
 - xgboost >1.6.1  # github.com/ESMValGroup/ESMValTool/issues/2779
 - med-diagnostics==0.0.1 # pining for now
 - access-med-tools==0.1.9
@@ -72,13 +72,11 @@ dependencies:
 - tqdm
 - moderngl
 - ffmpeg
+- ilamb==2.7.2
 - pip:
   - lavavu==1.8.84
   - railroad-diagrams ### Unlisted dependency of pip and pyparsing 
-  - git+https://github.com/rubisco-sfa/ILAMB.git@v2.7.1
   - git+https://github.com/ACCESS-NRI/ACCESS-Vis.git@v1.0.1
   - py360convert
   - numpy-quaternion
   
-# Julia (dependencies installed by separate script)
-- julia


### PR DESCRIPTION
Update ILAMB to v2.7.2 (use conda-forge package instead of git repo) Use access-nri channel in place of coecms for ucx-py