### PR TITLE
Remove COECMS channel and packages 

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -123,7 +123,6 @@ dependencies:
 - jupyter-server-proxy
 - sphinx
 - doc8
-- climtas
 - asyncssh
 - ants
 - xhistogram

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -117,7 +117,6 @@ dependencies:
 - palettable
 - xlrd
 - mdssdiff
-- mnctools
 - satpy
 - statsmodels
 - dask-labextension

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1,6 +1,5 @@
 name: analysis3
 channels:
-- coecms
 - conda-forge
 - accessnri
 - nodefaults

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -104,7 +104,6 @@ dependencies:
 - xrft
 - pylint
 - matplotlib-venn
-- umtools
 - nccmp
 - cmocean
 - marineHeatWaves

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -11,7 +11,6 @@ dependencies:
 - pip
 - sqlalchemy
 - libnetcdf=*=mpi_openmpi*
-- coecms-nci
 - cdo
 - hdf5
 - cartopy

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -168,7 +168,6 @@ dependencies:
 - autopep8
 - spyder-kernels
 - dask-xgboost
-- git-subtree
 - xarray-spatial
 - watermark
 - cvxpy

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -207,7 +207,6 @@ dependencies:
 - cafaz
 - pygam
 - pysal
-- xmhw
 - argopy
 - dataclasses-json
 - posix_ipc

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -116,7 +116,6 @@ dependencies:
 - mpi4py
 - palettable
 - xlrd
-- mdssdiff
 - satpy
 - statsmodels
 - dask-labextension

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -194,7 +194,6 @@ dependencies:
 - s3fs
 - kerchunk
 - ujson
-- cafaz
 - pygam
 - pysal
 - argopy

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -80,7 +80,6 @@ dependencies:
 - hupper
 - kealib
 - mo_pack
-- mule
 - cf-units
 - python-stratify
 - nbdime

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -160,7 +160,6 @@ dependencies:
 - dask-ml
 - mamba
 - pykrige
-- nci_intake_catalogue
 - cmdline_provenance
 - mplleaflet
 - branca

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -133,7 +133,6 @@ dependencies:
 - asyncssh
 - ants
 - xhistogram
-- cartopy_userconfig=1.0.gadi
 - geopy
 - ninja
 - hvplot

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -14,8 +14,6 @@ dependencies:
 - coecms-nci
 - cdo
 - hdf5
- #x basemap # Deprecated, see https://matplotlib.org/basemap/users/intro.html#deprecation-notice
- #x basemap-data-hires
 - cartopy
 - dask
 - distributed
@@ -67,9 +65,8 @@ dependencies:
 - gdal
 - libgdal
 - matplotlib
-#- matplotlib>=3.5.2|<=3.4.3  # pinned to solve  https://github.com/matplotlib/matplotlib/issues/21917
 - dreqpy
-- pint ###<0.24 ### https://github.com/Ouranosinc/xclim/issues/1771
+- pint
 - pycodestyle 
 - nc-time-axis
 - jq
@@ -79,7 +76,6 @@ dependencies:
 - scikit-learn
 - filelock
 - gsw
-#- nb_conda_kernels Maybe causing pb (it does not exist in access-med)
 - poppler
 - fiona
 - hupper
@@ -211,9 +207,7 @@ dependencies:
 - s3fs
 - kerchunk
 - ujson
-#- intake-thredds # Does not support intake 2
 - cafaz
-#- cdms2 incompatible with 3.11
 - pygam
 - pysal
 - xmhw

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -106,7 +106,6 @@ dependencies:
 - matplotlib-venn
 - umtools
 - nccmp
-- coecms-util
 - cmocean
 - marineHeatWaves
 - holoviews

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -106,7 +106,6 @@ dependencies:
 - pylint
 - matplotlib-venn
 - umtools
-- clef
 - nccmp
 - coecms-util
 - cmocean

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -116,7 +116,6 @@ dependencies:
 - mpi4py
 - palettable
 - xlrd
-- nccompress
 - mdssdiff
 - mnctools
 - satpy

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -219,7 +219,6 @@ dependencies:
 - lmfit
 - xclim
 - jupyter-resource-usage
-- acs_replica_intake
 - matchpy
 - mscorefonts
 - opencv  

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -128,7 +128,6 @@ dependencies:
 - jupyter-server-proxy
 - sphinx
 - doc8
-- pymunge
 - climtas
 - asyncssh
 - ants


### PR DESCRIPTION
To ensure the stability and maintainability of the *analysis3* environment, we will be removing packages currently sourced from the COECMS conda channel. This change aims to streamline package management and reduce potential conflicts, ensuring a more reliable and consistent environment for users. 

The targeted packages include:  
- acs_replica_intake  
- cafaz  
- cartopy_userconfig  
- Clef  
- climtas  
- coecms-nci  
- coecms-util  
- git-subtree  
- mdssdiff  
- mnctools  
- mule  
- nccompress  
- nci_intake_catalog  
- pymunge  
- umtools  
- xmhw  

Requests to re-include any of these packages can be submitted to ACCESS-NRI. We will assess the feasibility based on the level of support required. Please update any workflows or dependencies that rely on these packages accordingly.