### PR TITLE
adding pyshp for shapefile support in accessvis

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -179,6 +179,7 @@ dependencies:
 - pylint
 - pymannkendall
 - pysal
+- pyshp
 - pytables
 - pytest
 - pytest-cov


### PR DESCRIPTION
Adding pyshp to analysis3 environment for accessvis shapefile support.