### PR TITLE
Explicitly add polars 

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -166,6 +166,7 @@ dependencies:
 - pillow
 - pint
 - plotly
+- polars
 - poppler
 - posix_ipc
 - psutil


### PR DESCRIPTION
- Explicitly add polars, rather than waiting for it to get dragged in as dependency via intake related packages.

Polars has no dependencies so this shouldn't cause solver issues.