### PR TITLE
Create analysis3-25.06

### DIFF
--- a/environments/analysis3/config.sh
+++ b/environments/analysis3/config.sh
@@ -8,9 +8,7 @@
 ### outside_files_to_copy
 
 ### Optional config for custom deploy script
-export VERSION_TO_MODIFY=25.05
-export STABLE_VERSION=25.04
-export UNSTABLE_VERSION=25.05
+export VERSION_TO_MODIFY=25.06
 
 ### Version settings
 export ENVIRONMENT=analysis3

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -7,20 +7,20 @@ dependencies:
 - dask==2025.5.*
 - numpy==1.26.*
 - scipy==1.15.*
-- matplotlib==3.10.*
+- matplotlib>=3.9.*
 - pandas==2.2.*
 - scikit-image==0.25.*
 - scikit-learn==1.6.*
 - xarray==2025.4.*
-- ipython==9.0.*
-- zarr==3.0.*
+- ipython<9.0 # See ESMValTool
+- zarr<3.0 # Intake-ESM limitation
 - iris==3.12.*
 - netcdf4==1.7.*
 - libnetcdf=*=mpi_openmpi*
 - openmpi==4.1.6
 - pip=25.*
 - hdf5=1.14.*=mpi_openmpi* # issues with version 1.14.3, version 1.14.4 not available for openmpi < 5.0
-- jupyterlab==4.4.*
+- jupyterlab==4.3.*
 - cmor==3.9.*
 - accessnri::access-nri-intake==1.2.3
 - accessnri::access-py-telemetry==0.1.9

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -11,16 +11,16 @@ dependencies:
 - pandas==2.2.*
 - scikit-image==0.25.*
 - scikit-learn==1.6.*
-- xarray==2025.3.*
-- ipython==8.31.*
-- zarr==2.18.*
-- iris==3.11.*
+- xarray==2025.4.*
+- ipython==9.0.*
+- zarr==3.0.*
+- iris==3.12.*
 - netcdf4==1.7.*
 - libnetcdf=*=mpi_openmpi*
 - openmpi==4.1.6
 - pip=25.*
 - hdf5=1.14.*=mpi_openmpi* # issues with version 1.14.3, version 1.14.4 not available for openmpi < 5.0
-- jupyterlab==4.3.*
+- jupyterlab==4.4.*
 - cmor==3.9.*
 - accessnri::access-nri-intake==1.2.3
 - accessnri::access-py-telemetry==0.1.9

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - xarray==2025.4.*
 - ipython<9.0 # See ESMValTool
 - zarr<3.0 # Intake-ESM limitation
-- iris==3.11.*
+- iris==3.12.*
 - netcdf4==1.7.*
 - libnetcdf=*=mpi_openmpi*
 - openmpi==4.1.6

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - xarray==2025.4.*
 - ipython<9.0 # See ESMValTool
 - zarr<3.0 # Intake-ESM limitation
-- iris==3.12.*
+- iris==3.11.*
 - netcdf4==1.7.*
 - libnetcdf=*=mpi_openmpi*
 - openmpi==4.1.6


### PR DESCRIPTION
Update xarray to version 2025.4
Update iris to version 3.12

Some issues required relaxing matplotlib version...

ipython is limited to <9.0 because of ESMValTool
zarr is blocked <3.0 because of intake-ESM. @charles-turner-1 will investigate