### PR TITLE
Pytorch gpu

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1,6 +1,7 @@
 name: analysis3
 channels:
 - conda-forge
+- pytorch # for gpu-accelerated pytorch
 - nodefaults
 dependencies:
 - python==3.11.*
@@ -192,6 +193,8 @@ dependencies:
 - python-graphviz
 - python-magic
 - python-stratify
+- pytorch::pytorch
+- pytorch::pytorch-cuda
 - rasterio
 - rasterstats
 - rechunker

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1,7 +1,6 @@
 name: analysis3
 channels:
 - conda-forge
-- pytorch # for gpu-accelerated pytorch
 - nodefaults
 dependencies:
 - python==3.11.*
@@ -193,8 +192,7 @@ dependencies:
 - python-graphviz
 - python-magic
 - python-stratify
-- pytorch::pytorch
-- pytorch::pytorch-cuda
+- pytorch=*=cuda*
 - rasterio
 - rasterstats
 - rechunker


### PR DESCRIPTION
This uses conda-forge GPU-accelerated pytorch instead of the current CPU-only version. Note that PyTorch has somewhat recently [depracated](https://github.com/pytorch/pytorch/issues/138506) its `pytorch` conda channel and conda-forge is the best way to get pytorch via conda atm.

Multi-node should be usable via NCCL, but I may follow up with NCI to see if using their OMPI is necessary/possible with conda.