### PR TITLE
add pytorch-gpu and CONDA_OVERRIDE_GPU

### DIFF
--- a/environments/analysis3-edge/config.sh
+++ b/environments/analysis3-edge/config.sh
@@ -14,6 +14,9 @@ export VERSION_TO_MODIFY=25.07
 export ENVIRONMENT=analysis3_edge
 export FULLENV="${ENVIRONMENT}-${VERSION_TO_MODIFY}"
 
+### CUDA version
+export CONDA_OVERRIDE_CUDA=12
+
 declare -a rpms_to_remove=( "openssh-clients" "openssh-server" "openssh" )
 declare -a replace_from_apps=( "ucx/1.15.0" openmpi/5.9.5)
 declare -a outside_commands_to_include=( "pbs_tmrsh" "ssh" )

--- a/environments/analysis3-edge/environment.yml
+++ b/environments/analysis3-edge/environment.yml
@@ -178,6 +178,7 @@ dependencies:
 - python-graphviz
 - python-magic
 - python-stratify
+- pytorch-gpu
 - rasterio
 - rasterstats
 - rechunker


### PR DESCRIPTION
This uses conda-forge GPU-accelerated pytorch instead of the current CPU-only version. Note that PyTorch has somewhat recently https://github.com/pytorch/pytorch/issues/138506 its pytorch conda channel and conda-forge is the best way to get pytorch via conda atm.

Multi-node should be usable via NCCL, but I may follow up with NCI to see if using their OMPI is necessary/possible with conda.