### PR TITLE
Update access-mopper version to 2.3.0a4 in environment.yml

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -28,7 +28,7 @@ dependencies:
 - conda-forge::intake-dataframe-catalog==0.3.1
 - accessnri::yamanifest>=0.3.12
 - accessnri::access-med-tools==0.1.21
-- accessnri::access-mopper==2.0.0a12
+- accessnri::access-mopper==2.3.0a4
 - accessnri::benchcab==4.2.3
 - coecms::nchash
 - atteggiani::ants


### PR DESCRIPTION
This pull request updates the `access-mopper` dependency version in the `environments/analysis3/environment.yml` file. The package is upgraded from version `2.0.0a12` to `2.3.0a4`. 

- Upgraded `access-mopper` from version `2.0.0a12` to `2.3.0a4` in the environment dependencies.