### PR TITLE
Remove benchcab from analysis3 environment

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -29,7 +29,6 @@ dependencies:
 - accessnri::yamanifest>=0.3.12
 - accessnri::access-med-tools==0.1.21
 - accessnri::access-mopper==2.3.0a4
-- accessnri::benchcab==4.2.3
 - coecms::nchash
 - atteggiani::ants
 - atteggiani::mule


### PR DESCRIPTION
A separate environment for benchcab was added in #267. This change removes benchcab from the analysis3 environment.

Fixes #259