### PR TITLE
Fix payu in benchcab environment

### DIFF
--- a/environments/benchcab/environment.yml
+++ b/environments/benchcab/environment.yml
@@ -7,3 +7,4 @@ dependencies:
 # Note: the pinned benchcab version should match the BENCHCAB_VERSION
 # environment variable in environments/benchcab/config.sh:
 - accessnri::benchcab==4.2.3
+- accessnri::payu>=1.1.7

--- a/modules/common_v3
+++ b/modules/common_v3
@@ -43,5 +43,7 @@ setenv CONDA_EXE $prefix/$package/bin/micromamba
 setenv DASK_JOBQUEUE__PBS__PYTHON /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/python
 ### Set the path to the benchcab utility
 setenv BENCHCAB_PATH /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/benchcab
+### Set launcher script path for payu
+setenv ENV_LAUNCHER_SCRIPT_PATH /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/launcher.sh
 ### Set the path to the cartopy pre existing data
 setenv CARTOPY_DATA_DIR /g/data/xp65/public/apps/cartopy-data


### PR DESCRIPTION
This change updates the payu version and sets the `ENV_LAUNCHER_SCRIPT_PATH` environment variable to allow for its use from within the benchcab conda environment (see https://github.com/ACCESS-NRI/model-release-condaenv/issues/17 for more details).