### PR TITLE
Add palletable to environment.yml dependencies

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -168,6 +168,7 @@ dependencies:
   - numexpr
   - odc-geo
   - opencv
+  - palettable
   - panel
   - param
   - parcels


### PR DESCRIPTION
This pull request adds a new dependency to the `environments/analysis3/environment.yml` file. The change introduces the `palettable` package to the environment.

* Added `palettable` to the list of dependencies in `environments/analysis3/environment.yml` to support additional color palettes for data visualization.