### PR TITLE
Simplify CONDA_BASE_ENV_PATH assignment in launcher_conf.sh Fix #260

### DIFF
--- a/scripts/launcher_conf.sh
+++ b/scripts/launcher_conf.sh
@@ -1,10 +1,6 @@
 ### Subject to change
 export SINGULARITY_BINARY_PATH="/opt/singularity/bin/singularity"
 export CONTAINER_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__/etc/base.sif"
-if [[ "${CONDA_EXE}" ]]; then
-    export CONDA_BASE_ENV_PATH="${CONDA_EXE//\/bin\/micromamba/}"
-else
-    export CONDA_BASE_ENV_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__"
-fi
+export CONDA_BASE_ENV_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__"
 
 declare -a bind_dirs=( "/etc" "/half-root" "/local" "/ram" "/run" "/system" "/usr" "/var/lib/sss" "/var/run/munge" "/sys/fs/cgroup" "/iointensive" )


### PR DESCRIPTION
This pull request updates the way the `CONDA_BASE_ENV_PATH` environment variable is set in the `scripts/launcher_conf.sh` file, simplifying the logic and removing a conditional check.

* Environment variable assignment simplification:
  - The conditional logic that checked for the existence of `CONDA_EXE` and derived `CONDA_BASE_ENV_PATH` from it has been removed. Now, `CONDA_BASE_ENV_PATH` is always set to `__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__`, regardless of the presence of `CONDA_EXE`.
  
  This should fix issue #260 