### PR TITLE
Add configuration for Rapid Evaluation Framework

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -47,3 +47,6 @@ setenv BENCHCAB_PATH /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/
 setenv ENV_LAUNCHER_SCRIPT_PATH /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/launcher.sh
 ### Set the path to the cartopy pre existing data
 setenv CARTOPY_DATA_DIR /g/data/xp65/public/apps/cartopy-data
+### Set configuration for the Rapid Evaluation Framework
+setenv REF_DATASET_CACHE_DIR="/scratch/$PROJECT/climate-ref-cache"
+setenv REF_CONFIGURATION="/g/data/xp65/public/apps/climate-ref"


### PR DESCRIPTION
This pull request adds configuration settings for the Rapid Evaluation Framework to the `modules/common_v3` file. These new environment variables will help standardize the locations for the REF dataset cache and configuration, improving consistency and maintainability.

Rapid Evaluation Framework configuration:

* Added `REF_DATASET_CACHE_DIR` environment variable to specify the cache directory for REF datasets.
* Added `REF_CONFIGURATION` environment variable to specify the path to the REF configuration files.