### PR TITLE
Add uqstat to PATH in common_v3 configuration

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -50,3 +50,5 @@ setenv CARTOPY_DATA_DIR /g/data/xp65/public/apps/cartopy-data
 ### Set configuration for the Rapid Evaluation Framework
 setenv REF_DATASET_CACHE_DIR /scratch/xp65/climate-ref-cache
 setenv REF_CONFIGURATION /g/data/xp65/public/apps/climate-ref
+### Add uqstat 
+prepend-path PATH /g/data/xp65/public/apps/nci_scripts


### PR DESCRIPTION
This pull request makes a small change to the environment setup in `modules/common_v3`, specifically by updating the system path to include a directory for additional scripts.

* Added a line to prepend `/g/data/xp65/public/apps/nci_scripts` to the system `PATH`, enabling access to `uqstat` and other scripts.