### PR TITLE
Update some pip dependencies

### DIFF
--- a/environments/analysis3/config.sh
+++ b/environments/analysis3/config.sh
@@ -9,7 +9,7 @@
 
 ### Optional config for custom deploy script
 export VERSION_TO_MODIFY=25.09
-export STABLE_VERSION=25.07
+export STABLE_VERSION=25.08
 export UNSTABLE_VERSION=25.09
 
 ### Version settings

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -255,12 +255,12 @@ dependencies:
   - xwrf
 
   - pip:
-    - lavavu==1.9.5
+    - lavavu==1.9.10
     - railroad-diagrams ### Unlisted dependency of pip and pyparsing 
-    - accessvis==1.1.0
+    - accessvis==1.1.4
     - py360convert
     - numpy-quaternion
-    - climate-ref
+    - climate-ref[aft-providers]
     - pycnv
 
 # Needed for ESMValTool merge


### PR DESCRIPTION
This pull request updates several environment configuration files to bump versions of key dependencies and supported software. The main focus is on ensuring compatibility and access to new features by upgrading both the stable software version and several Python packages.

**Environment version update:**

* Updated the `STABLE_VERSION` in `config.sh` from `25.07` to `25.08` to support the latest stable release.

**Python dependency upgrades:**

* Upgraded `lavavu` from version `1.9.5` to `1.9.10` in `environment.yml` for improved visualization capabilities.
* Upgraded `accessvis` from `1.1.0` to `1.1.4` for enhanced access visualization features.
* Updated `climate-ref` to use the `[aft-providers]` extra, enabling additional provider support.