### PR TITLE
Add lavavu-osmesa dependency to environment.yml

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -256,6 +256,7 @@ dependencies:
 
   - pip:
     - lavavu==1.9.10
+    - lavavu-osmesa==1.9.10
     - railroad-diagrams ### Unlisted dependency of pip and pyparsing 
     - accessvis==1.1.4
     - py360convert


### PR DESCRIPTION
If we want it to work on CPU only nodes it will need to have the lavavu-osmesa package installed from pypi (which provides the software rendering fallback) instead of just lavavuOwen Kaluza: (note: lavavu-osmesa package supports GPU rendering too, it's just a larger package as includes lots of extra libraries for the software renderer, had to remove those from regular lavavu as I ran out of my space allocation on PyPi)