### PR TITLE
Update benchcab to version 4.2.4

### DIFF
--- a/environments/benchcab/config.sh
+++ b/environments/benchcab/config.sh
@@ -1,5 +1,5 @@
 # Note: BENCHCAB_VERSION should match the version of benchcab in
 # environments/benchcab/environment.yml:
-BENCHCAB_VERSION=4.2.3
+BENCHCAB_VERSION=4.2.4
 export STABLE_VERSION="${BENCHCAB_VERSION}"
 export FULLENV="benchcab-${BENCHCAB_VERSION}"

--- a/environments/benchcab/environment.yml
+++ b/environments/benchcab/environment.yml
@@ -6,5 +6,5 @@ channels:
 dependencies:
 # Note: the pinned benchcab version should match the BENCHCAB_VERSION
 # environment variable in environments/benchcab/config.sh:
-- accessnri::benchcab==4.2.3
+- accessnri::benchcab==4.2.4
 - accessnri::payu>=1.1.7


### PR DESCRIPTION
Some minor changes were added in [4.2.4](https://github.com/CABLE-LSM/benchcab/releases/tag/v4.2.4) to address some problems running from `xp65`.

Should be working smoothly now. 🤞 