### PR TITLE
Fix benchcab module aliasing

### DIFF
--- a/environments/benchcab/config.sh
+++ b/environments/benchcab/config.sh
@@ -1,5 +1,6 @@
 # Note: BENCHCAB_VERSION should match the version of benchcab in
 # environments/benchcab/environment.yml:
 BENCHCAB_VERSION=4.2.4
+export ENVIRONMENT="benchcab"
 export STABLE_VERSION="${BENCHCAB_VERSION}"
-export FULLENV="benchcab-${BENCHCAB_VERSION}"
+export FULLENV="${ENVIRONMENT}-${BENCHCAB_VERSION}"

--- a/environments/benchcab/deploy.sh
+++ b/environments/benchcab/deploy.sh
@@ -1,32 +1,8 @@
-### Update stable/unstable if necessary
-CURRENT_STABLE=$( get_aliased_module "${MODULE_NAME}"/analysis3 "${CONDA_MODULE_PATH}" )
+CURRENT_ALIAS=$( get_aliased_module "${MODULE_NAME}/${ENVIRONMENT}" "${CONDA_MODULE_PATH}" )
 NEXT_STABLE="${ENVIRONMENT}-${STABLE_VERSION}"
-CURRENT_UNSTABLE=$( get_aliased_module "${MODULE_NAME}"/analysis3-unstable "${CONDA_MODULE_PATH}" )
-NEXT_UNSTABLE="${ENVIRONMENT}-${UNSTABLE_VERSION}"
 
-# Define the aliases for benchcab
-STABLE_ALIASES="benchcab"
-UNSTABLE_ALIASES="benchcab-unstable"
-
-# Check if this is a new unstable version being created for the first time
-if [[ -z "${CURRENT_UNSTABLE}" ]] && [[ "${NEXT_UNSTABLE}" != "${NEXT_STABLE}" ]]; then
-    echo "Creating new unstable version ${NEXT_UNSTABLE}, promoting ${NEXT_STABLE} to stable"
-    write_modulerc "${NEXT_STABLE}" "${NEXT_UNSTABLE}" "${ENVIRONMENT}" "${CONDA_MODULE_PATH}" "${MODULE_NAME}" "${STABLE_ALIASES}" "${UNSTABLE_ALIASES}"
-    symlink_atomic_update "${CONDA_INSTALLATION_PATH}"/envs/"${ENVIRONMENT}" "${NEXT_STABLE}"
-    symlink_atomic_update "${CONDA_SCRIPT_PATH}"/"${ENVIRONMENT}".d "${NEXT_STABLE}".d
-    symlink_atomic_update "${CONDA_INSTALLATION_PATH}"/envs/"${ENVIRONMENT}"-unstable "${NEXT_UNSTABLE}"
-    symlink_atomic_update "${CONDA_SCRIPT_PATH}"/"${ENVIRONMENT}"-unstable.d "${NEXT_UNSTABLE}".d
-else
-    echo "Unstable version already exists or same as stable - no .modulerc changes needed"
-    # Still update symlinks if versions changed
-    if ! [[ "${CURRENT_STABLE}" == "${MODULE_NAME}/${NEXT_STABLE}" ]]; then
-        echo "Updating stable symlinks to ${NEXT_STABLE}"
-        symlink_atomic_update "${CONDA_INSTALLATION_PATH}"/envs/"${ENVIRONMENT}" "${NEXT_STABLE}"
-        symlink_atomic_update "${CONDA_SCRIPT_PATH}"/"${ENVIRONMENT}".d "${NEXT_STABLE}".d
-    fi
-    if ! [[ "${CURRENT_UNSTABLE}" == "${MODULE_NAME}/${NEXT_UNSTABLE}" ]] && [[ "${NEXT_UNSTABLE}" != "${NEXT_STABLE}" ]]; then
-        echo "Updating unstable symlinks to ${NEXT_UNSTABLE}"
-        symlink_atomic_update "${CONDA_INSTALLATION_PATH}"/envs/"${ENVIRONMENT}"-unstable "${NEXT_UNSTABLE}"
-        symlink_atomic_update "${CONDA_SCRIPT_PATH}"/"${ENVIRONMENT}"-unstable.d "${NEXT_UNSTABLE}".d
-    fi
+if ! [[ "${CURRENT_ALIAS}" == "${MODULE_NAME}/${NEXT_STABLE}" ]]; then
+    # Update the current module alias to point to the next stable version:
+    # usage: write_modulerc <next_stable> <next_unstable> <environment> <conda_module_path> <module_name> <stable_aliases> <unstable_aliases>
+    write_modulerc "${NEXT_STABLE}" "" "${ENVIRONMENT}" "${CONDA_MODULE_PATH}" "${MODULE_NAME}" "${ENVIRONMENT}" ""
 fi


### PR DESCRIPTION
This change should fix the automated module aliasing for the `conda/benchcab` environment module on deployment.