### PR TITLE
Add minor version pins for jupyterlab & notebook. Bugfix pins cause i…

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - openmpi==4.1.6
   - pip=25.*
   - hdf5=1.14.*=mpi_openmpi* # issues with version 1.14.3, version 1.14.4 not available for openmpi < 5.0
-  - jupyterlab==4.4.*
+  - jupyterlab==4.3.*
   - cmor==3.9.*
   - accessnri::access-nri-intake==1.3.0
   - accessnri::intake-esm-access==2025.9.18
@@ -163,7 +163,7 @@ dependencies:
   - neutralocean
   - ninja
   - nodejs
-  - notebook
+  - notebook==4.4.*
   - numba
   - numexpr
   - odc-geo


### PR DESCRIPTION
Bugfix pins cause issues with pixi solver:
```bash
pixi lock                                                                                                                                                                                                                    13.2s  Wed  1 Oct 07:36:33 2025
Error:   × failed to solve 'analysis3' for linux-64
  ├─▶ failed to solve the environment
  ╰─▶ Cannot solve the request because of: The following packages are incompatible
      ├─ jupyterlab ==4.3.0 can be installed with any of the following options:
      │  └─ jupyterlab 4.3.0
      └─ notebook ==7.3.0 cannot be installed because there are no viable options:
         └─ notebook 7.3.0 would require
            └─ jupyterlab >=4.3.2,<4.4, which cannot be installed because there are no viable options:
               └─ jupyterlab 4.3.8, which conflicts with the versions reported above.
```

I assume conda will be the same.