### PR TITLE
Analysis3 25.10

### DIFF
--- a/environments/analysis3/config.sh
+++ b/environments/analysis3/config.sh
@@ -8,9 +8,9 @@
 ### outside_files_to_copy
 
 ### Optional config for custom deploy script
-export VERSION_TO_MODIFY=25.09
-export STABLE_VERSION=25.08
-export UNSTABLE_VERSION=25.09
+export VERSION_TO_MODIFY=25.10
+export STABLE_VERSION=25.09
+export UNSTABLE_VERSION=25.10
 
 ### Version settings
 export ENVIRONMENT=analysis3

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -5,14 +5,14 @@ channels:
   - nodefaults
 dependencies:
   - python==3.11.*
-  - dask==2025.5.*
+  - dask==2025.9.*
   - numpy==1.26.*
   - scipy==1.16.*
   - matplotlib>=3.9.*
   - pandas==2.3.*
   - scikit-image==0.25.*
   - scikit-learn==1.7.*
-  - xarray==2025.6.*
+  - xarray==2025.9.*
   - ipython<9.0 # See ESMValTool
   - zarr>=3.1.0
   - iris==3.12.*


### PR DESCRIPTION
This pull request updates the environment configuration for `analysis3` to use newer versions of several core packages and increments the version identifiers to reflect these updates. The changes ensure the environment remains current with the latest stable releases.

Version updates:

* Updated the `VERSION_TO_MODIFY`, `STABLE_VERSION`, and `UNSTABLE_VERSION` variables in `config.sh` to `25.10`, `25.09`, and `25.10` respectively, reflecting the move to the latest stable and unstable versions.

Dependency upgrades:

* Upgraded `dask` from `2025.5.*` to `2025.9.*` in `environment.yml` to use the latest release.
* Upgraded `xarray` from `2025.6.*` to `2025.9.*` in `environment.yml` for improved compatibility and features.