### PR TITLE
analysis3-edge-25.10

### DIFF
--- a/environments/analysis3-edge/config.sh
+++ b/environments/analysis3-edge/config.sh
@@ -8,9 +8,9 @@
 ### outside_files_to_copy
 
 ### Optional config for custom deploy script
-export VERSION_TO_MODIFY=25.09
-export STABLE_VERSION=25.08
-export UNSTABLE_VERSION=25.09
+export VERSION_TO_MODIFY=25.10
+export STABLE_VERSION=25.09
+export UNSTABLE_VERSION=25.10
 
 ### Version settings
 export ENVIRONMENT=analysis3_edge

--- a/environments/analysis3-edge/environment.yml
+++ b/environments/analysis3-edge/environment.yml
@@ -5,14 +5,14 @@ channels:
 dependencies:
 # SPEC0 packages
 - python==3.11.*
-- dask==2025.7.*
+- dask==2025.9.*
 - numpy>=2.0
 - scipy==1.15.*
 - matplotlib>3.9
 - pandas==2.3.*
 - scikit-image==0.25.*
 - scikit-learn==1.7.*
-- xarray==2025.7.*
+- xarray==2025.9.*
 - ipython<9.0
 - zarr>3.0
 - iris==3.12.*


### PR DESCRIPTION
…odify deployment version settings
This pull request updates the environment configuration for the `analysis3-edge` deployment, primarily focusing on bumping version numbers for both the deployment scripts and key Python packages to their latest releases.

Version updates for deployment scripts:

* Updated the `VERSION_TO_MODIFY`, `STABLE_VERSION`, and `UNSTABLE_VERSION` variables in `config.sh` to reflect the new release versions (`25.10` for modify/unstable, `25.09` for stable).

Python package upgrades for environment:

* Upgraded `dask` and `xarray` dependencies in `environment.yml` from `2025.7.*` to `2025.9.*` to use the latest versions available.